### PR TITLE
fix: fixing the rbac for updating the finalizers

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,13 +11,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - kms.cnrm.cloud.google.com
-  resources:
-  - kmskeyrings/finalizers
-  verbs:
   - update
+  - watch
 - apiGroups:
   - redis.cnrm.cloud.google.com
   resources:
@@ -25,13 +20,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - redis.cnrm.cloud.google.com
-  resources:
-  - redisinstances/finalizers
-  verbs:
   - update
+  - watch
 - apiGroups:
   - sql.cnrm.cloud.google.com
   resources:
@@ -39,13 +29,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - sql.cnrm.cloud.google.com
-  resources:
-  - sqlinstances/finalizers
-  verbs:
   - update
+  - watch
 - apiGroups:
   - storage.cnrm.cloud.google.com
   resources:
@@ -53,13 +38,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - storage.cnrm.cloud.google.com
-  resources:
-  - storagebuckets/finalizers
-  verbs:
   - update
+  - watch
 - apiGroups:
   - tags.cnrm.cloud.google.com
   resources:

--- a/helm-chart/gcp-config-connector-tagging-operator/templates/manager-rbac.yaml
+++ b/helm-chart/gcp-config-connector-tagging-operator/templates/manager-rbac.yaml
@@ -12,13 +12,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - kms.cnrm.cloud.google.com
-  resources:
-  - kmskeyrings/finalizers
-  verbs:
   - update
+  - watch
 - apiGroups:
   - redis.cnrm.cloud.google.com
   resources:
@@ -26,13 +21,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - redis.cnrm.cloud.google.com
-  resources:
-  - redisinstances/finalizers
-  verbs:
   - update
+  - watch
 - apiGroups:
   - sql.cnrm.cloud.google.com
   resources:
@@ -40,13 +30,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - sql.cnrm.cloud.google.com
-  resources:
-  - sqlinstances/finalizers
-  verbs:
   - update
+  - watch
 - apiGroups:
   - storage.cnrm.cloud.google.com
   resources:
@@ -54,13 +39,8 @@ rules:
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - storage.cnrm.cloud.google.com
-  resources:
-  - storagebuckets/finalizers
-  verbs:
   - update
+  - watch
 - apiGroups:
   - tags.cnrm.cloud.google.com
   resources:

--- a/internal/controller/resources/kms.go
+++ b/internal/controller/resources/kms.go
@@ -8,8 +8,7 @@ import (
 	"github.com/deliveryhero/gcp-config-connector-tagging-operator/internal/controller"
 )
 
-// +kubebuilder:rbac:groups=kms.cnrm.cloud.google.com,resources=kmskeyrings,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kms.cnrm.cloud.google.com,resources=kmskeyrings/finalizers,verbs=update
+// +kubebuilder:rbac:groups=kms.cnrm.cloud.google.com,resources=kmskeyrings,verbs=get;list;watch;update
 
 var _ controller.ResourceMetadataProvider[kmsv1beta1.KMSKeyRing] = &KMSKeyRingMetadataProvider{}
 

--- a/internal/controller/resources/redis.go
+++ b/internal/controller/resources/redis.go
@@ -23,8 +23,7 @@ import (
 	"github.com/deliveryhero/gcp-config-connector-tagging-operator/internal/controller"
 )
 
-// +kubebuilder:rbac:groups=redis.cnrm.cloud.google.com,resources=redisinstances,verbs=get;list;watch
-// +kubebuilder:rbac:groups=redis.cnrm.cloud.google.com,resources=redisinstances/finalizers,verbs=update
+// +kubebuilder:rbac:groups=redis.cnrm.cloud.google.com,resources=redisinstances,verbs=get;list;watch;update
 
 var _ controller.ResourceMetadataProvider[redisv1beta1.RedisInstance] = &RedisInstanceMetadataProvider{}
 

--- a/internal/controller/resources/sql.go
+++ b/internal/controller/resources/sql.go
@@ -25,8 +25,7 @@ import (
 	"github.com/deliveryhero/gcp-config-connector-tagging-operator/internal/controller"
 )
 
-// +kubebuilder:rbac:groups=sql.cnrm.cloud.google.com,resources=sqlinstances,verbs=get;list;watch
-// +kubebuilder:rbac:groups=sql.cnrm.cloud.google.com,resources=sqlinstances/finalizers,verbs=update
+// +kubebuilder:rbac:groups=sql.cnrm.cloud.google.com,resources=sqlinstances,verbs=get;list;watch;update
 
 var _ controller.ResourceMetadataProvider[sqlv1beta1.SQLInstance] = &SQLInstanceMetadataProvider{}
 

--- a/internal/controller/resources/storage.go
+++ b/internal/controller/resources/storage.go
@@ -25,8 +25,7 @@ import (
 	"github.com/deliveryhero/gcp-config-connector-tagging-operator/internal/controller"
 )
 
-// +kubebuilder:rbac:groups=storage.cnrm.cloud.google.com,resources=storagebuckets,verbs=get;list;watch
-// +kubebuilder:rbac:groups=storage.cnrm.cloud.google.com,resources=storagebuckets/finalizers,verbs=update
+// +kubebuilder:rbac:groups=storage.cnrm.cloud.google.com,resources=storagebuckets,verbs=get;list;watch;update
 
 var _ controller.ResourceMetadataProvider[storagev1beta1.StorageBucket] = &StorageBucketMetadataProvider{}
 


### PR DESCRIPTION

We are encountering an issue while testing the new RBAC configuration for our tagging-operator. The operator is unable to patch TagBindings or the finalizer metadata to taggable resources when we restrict permissions as shown in this code.
However, when we add update permissions to the redisinstances/storagebuckets resource (+kubebuilder:rbac:groups=redis.cnrm.cloud.google.com,resources=redisinstances,verbs=get;list;watch;update), everything works as expected.
My initial debugging indicates that the Config Connector resource CRDs, including the one for RedisInstance/Storagebuctes ..., do not define a finalizers subresource. Therefore, I guess the update permission on the main resource resource is needed to manage finalizers.
/usr/local/bin/kubectl get crd storagebuckets.storage.cnrm.cloud.google.com   -oyaml  
# No finalizers can be found for the CRD