### PR TITLE
fix: using project client to fetch the project number for redis resource ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ This project helps solve this issue by adding a layer that syncs tag keys and va
 - Kubectl version v1.11.3+
 - Access to a Kubernetes v1.11.3+ cluster with Config Connector v1.121.0+ installed.
 
-### Deploying on the Cluster Using Helm
+### Deploying on the cluster using Helm
 
-**Install the chart from the Helm repository:**
+#### Install the chart from the Helm repository
 
 ```sh
 helm install gcp-config-connector-tagging-operator oci://ghcr.io/deliveryhero/gcp-config-connector-tagging-operator/helm-chart/gcp-config-connector-tagging-operator \
@@ -32,16 +32,15 @@ helm install gcp-config-connector-tagging-operator oci://ghcr.io/deliveryhero/gc
   --namespace "gcp-config-connector-tagging-operator-system"
 ```
 
-### Grant the `tagAdmin` Role to the Service Account
+#### Grant the `tagAdmin`  and `tagUser` roles to the Tagging Operator Kubenetes Service Account
 
-```sh
-PROJECT_ID=<your-gcp-project-id>
-PROJECT_NUMBER=<your-gcp-project-number>
-gcloud projects add-iam-policy-binding ${PROJECT_ID} \
-  --role=roles/resourcemanager.tagAdmin \
-  --member=principal://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${PROJECT_ID}.svc.id.goog/subject/ns/gcp-config-connector-tagging-operator-system/sa/gcp-config-connector-tagging-operator-controller-manager \
-  --condition=None
-```
+Default Tagging Operator Kubenetes Service Account User is `gcp-config-connector-tagging-operator-controller-manager` 
+
+Refer [Authenticate to Google Cloud APIs from GKE workloads](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
+
+#### Grant the `tagUser` role to the Config Connector Kubenetes Service Account
+
+Refer [Authenticate to Google Cloud APIs from GKE workloads](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
 
 ### Deploying on the Cluster
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -180,7 +180,14 @@ func main() {
 		setupLog.Error(err, "unable to create tag values client")
 		os.Exit(1)
 	}
-	tagsManager := gcp.NewTagsManager(tagKeysClient, tagValuesClient)
+
+	projectClient, err := resourcemanager.NewProjectsClient(ctx)
+	if err != nil {
+		setupLog.Error(err, "unable to create project client")
+		os.Exit(1)
+	}
+
+	tagsManager := gcp.NewTagsManager(tagKeysClient, tagValuesClient, projectClient)
 
 	err = controller.SetupTagBindingIndex(mgr)
 	if err != nil {

--- a/internal/controller/resources/kms.go
+++ b/internal/controller/resources/kms.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	kmsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/kms/v1beta1"
 
 	"github.com/deliveryhero/gcp-config-connector-tagging-operator/internal/controller"
@@ -34,11 +35,11 @@ func (in *KMSKeyRingMetadataProvider) GetResourceLocation(r *kmsv1beta1.KMSKeyRi
 	return r.Spec.Location
 }
 
-func (in *KMSKeyRingMetadataProvider) GetResourceID(projectID string, r *kmsv1beta1.KMSKeyRing) string {
+func (in *KMSKeyRingMetadataProvider) GetResourceID(projectInfo *resourcemanagerpb.Project, r *kmsv1beta1.KMSKeyRing) string {
 	name := r.Name
 	if r.Spec.ResourceID != nil {
 		name = *r.Spec.ResourceID
 	}
 
-	return fmt.Sprintf("//cloudkms.googleapis.com/projects/%s/locations/%s/keyRings/%s", projectID, r.Spec.Location, name)
+	return fmt.Sprintf("//cloudkms.googleapis.com/projects/%s/locations/%s/keyRings/%s", projectInfo.ProjectId, r.Spec.Location, name)
 }

--- a/internal/controller/resources/kms_test.go
+++ b/internal/controller/resources/kms_test.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"testing"
 
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	kmsv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/kms/v1beta1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,10 +35,10 @@ func TestKMSKeyRingMetadataProvider_GetResourceID(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		r         *kmsv1beta1.KMSKeyRing
-		projectID string
-		want      string
+		name        string
+		r           *kmsv1beta1.KMSKeyRing
+		projectInfo *resourcemanagerpb.Project
+		want        string
 	}{
 		{
 			name: "with generated name",
@@ -50,8 +51,10 @@ func TestKMSKeyRingMetadataProvider_GetResourceID(t *testing.T) {
 					Location: "us-central1",
 				},
 			},
-			projectID: "test-project",
-			want:      "//cloudkms.googleapis.com/projects/test-project/locations/us-central1/keyRings/test-key-ring",
+			projectInfo: &resourcemanagerpb.Project{
+				ProjectId: "test-project",
+			},
+			want: "//cloudkms.googleapis.com/projects/test-project/locations/us-central1/keyRings/test-key-ring",
 		},
 		{
 			name: "with overridden resource id",
@@ -65,8 +68,10 @@ func TestKMSKeyRingMetadataProvider_GetResourceID(t *testing.T) {
 					ResourceID: ptr.To("overridden-key-ring-id"),
 				},
 			},
-			projectID: "test-project",
-			want:      "//cloudkms.googleapis.com/projects/test-project/locations/us-central1/keyRings/overridden-key-ring-id",
+			projectInfo: &resourcemanagerpb.Project{
+				ProjectId: "test-project",
+			},
+			want: "//cloudkms.googleapis.com/projects/test-project/locations/us-central1/keyRings/overridden-key-ring-id",
 		},
 	}
 
@@ -74,7 +79,7 @@ func TestKMSKeyRingMetadataProvider_GetResourceID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &KMSKeyRingMetadataProvider{}
 
-			got := p.GetResourceID(tc.projectID, tc.r)
+			got := p.GetResourceID(tc.projectInfo, tc.r)
 
 			require.Equal(t, tc.want, got)
 		})

--- a/internal/controller/resources/redis.go
+++ b/internal/controller/resources/redis.go
@@ -47,7 +47,7 @@ func (in *RedisInstanceMetadataProvider) GetResourceID(projectInfo *resourcemana
 
 	region := r.Spec.Region
 
-	projectNumber := projectNumRe.FindString(projectInfo.Name)
+	projectNumber := strings.TrimPrefix(projectInfo.Name, "projects/")
 
 	return fmt.Sprintf("//redis.googleapis.com/projects/%s/locations/%s/instances/%s", projectNumber, region, name)
 }

--- a/internal/controller/resources/redis.go
+++ b/internal/controller/resources/redis.go
@@ -18,15 +18,11 @@ package resources
 
 import (
 	"fmt"
-	"regexp"
+	"strings"
 
 	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	redisv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/redis/v1beta1"
 	"github.com/deliveryhero/gcp-config-connector-tagging-operator/internal/controller"
-)
-
-var (
-	projectNumRe = regexp.MustCompile(`[0-9]+`)
 )
 
 // +kubebuilder:rbac:groups=redis.cnrm.cloud.google.com,resources=redisinstances,verbs=get;list;watch;update

--- a/internal/controller/resources/sql.go
+++ b/internal/controller/resources/sql.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	"k8s.io/utils/ptr"
 
 	sqlv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/sql/v1beta1"
@@ -35,11 +36,11 @@ func (in *SQLInstanceMetadataProvider) GetResourceLocation(r *sqlv1beta1.SQLInst
 	return ptr.Deref(r.Spec.Region, "")
 }
 
-func (in *SQLInstanceMetadataProvider) GetResourceID(projectID string, r *sqlv1beta1.SQLInstance) string {
+func (in *SQLInstanceMetadataProvider) GetResourceID(projectInfo *resourcemanagerpb.Project, r *sqlv1beta1.SQLInstance) string {
 	name := r.Name
 	if r.Spec.ResourceID != nil {
 		name = *r.Spec.ResourceID
 	}
 
-	return fmt.Sprintf("//sqladmin.googleapis.com/projects/%s/instances/%s", projectID, name)
+	return fmt.Sprintf("//sqladmin.googleapis.com/projects/%s/instances/%s", projectInfo.ProjectId, name)
 }

--- a/internal/controller/resources/sql_test.go
+++ b/internal/controller/resources/sql_test.go
@@ -19,11 +19,11 @@ package resources
 import (
 	"testing"
 
-	"k8s.io/utils/ptr"
-
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	sqlv1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/sql/v1beta1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestSQLInstanceMetadataProvider_GetResourceID(t *testing.T) {
@@ -35,10 +35,10 @@ func TestSQLInstanceMetadataProvider_GetResourceID(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		r         *sqlv1beta1.SQLInstance
-		projectID string
-		want      string
+		name        string
+		r           *sqlv1beta1.SQLInstance
+		projectInfo *resourcemanagerpb.Project
+		want        string
 	}{
 		{
 			name: "with generated name",
@@ -51,8 +51,10 @@ func TestSQLInstanceMetadataProvider_GetResourceID(t *testing.T) {
 					Region: ptr.To("us-central1"),
 				},
 			},
-			projectID: "test-project",
-			want:      "//sqladmin.googleapis.com/projects/test-project/instances/test-instance",
+			projectInfo: &resourcemanagerpb.Project{
+				ProjectId: "test-project",
+			},
+			want: "//sqladmin.googleapis.com/projects/test-project/instances/test-instance",
 		},
 		{
 			name: "with overridden resource id",
@@ -66,8 +68,10 @@ func TestSQLInstanceMetadataProvider_GetResourceID(t *testing.T) {
 					ResourceID: ptr.To("overridden-instance-id"),
 				},
 			},
-			projectID: "test-project",
-			want:      "//sqladmin.googleapis.com/projects/test-project/instances/overridden-instance-id",
+			projectInfo: &resourcemanagerpb.Project{
+				ProjectId: "test-project",
+			},
+			want: "//sqladmin.googleapis.com/projects/test-project/instances/overridden-instance-id",
 		},
 	}
 
@@ -75,7 +79,7 @@ func TestSQLInstanceMetadataProvider_GetResourceID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &SQLInstanceMetadataProvider{}
 
-			got := p.GetResourceID(tc.projectID, tc.r)
+			got := p.GetResourceID(tc.projectInfo, tc.r)
 
 			require.Equal(t, tc.want, got)
 		})

--- a/internal/controller/resources/storage.go
+++ b/internal/controller/resources/storage.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	storagev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/storage/v1beta1"
 	"k8s.io/utils/ptr"
 
@@ -35,7 +36,7 @@ func (in *StorageBucketMetadataProvider) GetResourceLocation(r *storagev1beta1.S
 	return ptr.Deref(r.Spec.Location, "")
 }
 
-func (in *StorageBucketMetadataProvider) GetResourceID(_ string, r *storagev1beta1.StorageBucket) string {
+func (in *StorageBucketMetadataProvider) GetResourceID(_ *resourcemanagerpb.Project, r *storagev1beta1.StorageBucket) string {
 	name := r.Name
 	if r.Spec.ResourceID != nil {
 		name = *r.Spec.ResourceID

--- a/internal/controller/resources/storage_test.go
+++ b/internal/controller/resources/storage_test.go
@@ -19,11 +19,11 @@ package resources
 import (
 	"testing"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
-
+	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	storagev1beta1 "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/storage/v1beta1"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestStorageBucketMetadataProvider_GetResourceID(t *testing.T) {
@@ -35,10 +35,10 @@ func TestStorageBucketMetadataProvider_GetResourceID(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		r         *storagev1beta1.StorageBucket
-		projectID string
-		want      string
+		name        string
+		r           *storagev1beta1.StorageBucket
+		projectInfo *resourcemanagerpb.Project
+		want        string
 	}{
 		{
 			name: "with generated name",
@@ -51,8 +51,10 @@ func TestStorageBucketMetadataProvider_GetResourceID(t *testing.T) {
 					Location: ptr.To("us-central1"),
 				},
 			},
-			projectID: "test-project",
-			want:      "//storage.googleapis.com/projects/_/buckets/test-bucket",
+			projectInfo: &resourcemanagerpb.Project{
+				ProjectId: "test-project",
+			},
+			want: "//storage.googleapis.com/projects/_/buckets/test-bucket",
 		},
 		{
 			name: "with overridden resource id",
@@ -66,8 +68,10 @@ func TestStorageBucketMetadataProvider_GetResourceID(t *testing.T) {
 					ResourceID: ptr.To("overridden-bucket-id"),
 				},
 			},
-			projectID: "test-project",
-			want:      "//storage.googleapis.com/projects/_/buckets/overridden-bucket-id",
+			projectInfo: &resourcemanagerpb.Project{
+				ProjectId: "test-project",
+			},
+			want: "//storage.googleapis.com/projects/_/buckets/overridden-bucket-id",
 		},
 	}
 
@@ -75,7 +79,8 @@ func TestStorageBucketMetadataProvider_GetResourceID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &StorageBucketMetadataProvider{}
 
-			got := p.GetResourceID(tc.projectID, tc.r)
+			got := p.GetResourceID(tc.projectInfo, tc.r)
+
 			require.Equal(t, tc.want, got)
 		})
 	}

--- a/internal/controller/taggable_controller.go
+++ b/internal/controller/taggable_controller.go
@@ -226,9 +226,9 @@ func (r *TaggableResourceReconciler[T, P, PT]) generateBinding(resource PT, proj
 			},
 		},
 	}
-	if projectInfo.ProjectId != "" {
-		binding.Annotations[projectIDAnnotation] = projectInfo.ProjectId
-	}
+
+	binding.Annotations[projectIDAnnotation] = projectInfo.ProjectId
+
 	if err := ctrl.SetControllerReference(resource, binding, r.Scheme); err != nil {
 		return nil, err
 	}

--- a/internal/gcp/tags.go
+++ b/internal/gcp/tags.go
@@ -38,21 +38,24 @@ type TagsManager interface {
 	CreateKey(ctx context.Context, projectID string, key string) (*resourcemanagerpb.TagKey, error)
 	LookupValue(ctx context.Context, projectID string, key string, value string) (*resourcemanagerpb.TagValue, error)
 	CreateValue(ctx context.Context, projectID string, key string, value string) (*resourcemanagerpb.TagValue, error)
+	GetProjectInfo(ctx context.Context, projectID string) (*resourcemanagerpb.Project, error)
 }
 
 type tagsManager struct {
-	keysClient   *resourcemanager.TagKeysClient
-	valuesClient *resourcemanager.TagValuesClient
-	cache        *cache.Cache
+	keysClient     *resourcemanager.TagKeysClient
+	valuesClient   *resourcemanager.TagValuesClient
+	projectsClient *resourcemanager.ProjectsClient
+	cache          *cache.Cache
 }
 
 // TODO add logging to this file
 
-func NewTagsManager(keysClient *resourcemanager.TagKeysClient, valuesClient *resourcemanager.TagValuesClient) TagsManager {
+func NewTagsManager(keysClient *resourcemanager.TagKeysClient, valuesClient *resourcemanager.TagValuesClient, projectClient *resourcemanager.ProjectsClient) TagsManager {
 	return &tagsManager{
-		keysClient:   keysClient,
-		valuesClient: valuesClient,
-		cache:        cache.New(tagCacheDuration, tagCacheDuration),
+		keysClient:     keysClient,
+		valuesClient:   valuesClient,
+		projectsClient: projectClient,
+		cache:          cache.New(tagCacheDuration, tagCacheDuration),
 	}
 }
 
@@ -149,4 +152,17 @@ func cacheKeyTagKey(key string) string {
 
 func cacheKeyTagValue(key string, value string) string {
 	return fmt.Sprintf("value:%s:%s", key, value)
+}
+
+func (m *tagsManager) GetProjectInfo(ctx context.Context, projectID string) (*resourcemanagerpb.Project, error) {
+
+	req := &resourcemanagerpb.GetProjectRequest{
+		Name: "projects/" + projectID,
+	}
+
+	project, err := m.projectsClient.GetProject(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project: %v", err)
+	}
+	return project, nil
 }

--- a/internal/gcp/tags.go
+++ b/internal/gcp/tags.go
@@ -156,6 +156,16 @@ func cacheKeyTagValue(key string, value string) string {
 
 func (m *tagsManager) GetProjectInfo(ctx context.Context, projectID string) (*resourcemanagerpb.Project, error) {
 
+	if projectID == "" {
+		return nil, fmt.Errorf("project ID cannot be empty")
+	}
+
+	cacheKey := fmt.Sprintf("project:%s", projectID)
+	cachedProject, found := m.cache.Get(cacheKey)
+	if found {
+		return cachedProject.(*resourcemanagerpb.Project), nil
+	}
+
 	req := &resourcemanagerpb.GetProjectRequest{
 		Name: "projects/" + projectID,
 	}
@@ -164,5 +174,7 @@ func (m *tagsManager) GetProjectInfo(ctx context.Context, projectID string) (*re
 	if err != nil {
 		return nil, fmt.Errorf("failed to get project: %v", err)
 	}
+
+	m.cache.Set(cacheKey, project, tagCacheDuration)
 	return project, nil
 }

--- a/internal/gcp/tags_test.go
+++ b/internal/gcp/tags_test.go
@@ -92,7 +92,7 @@ func TestLookupKeyWithFakeGRPCServer(t *testing.T) {
 	keysClient, err := resourcemanager.NewTagKeysClient(ctx, option.WithGRPCConn(conn))
 	assert.NoError(t, err, "Failed to create TagKeysClient")
 
-	mgr := NewTagsManager(keysClient, nil)
+	mgr := NewTagsManager(keysClient, nil, nil)
 
 	key, err := mgr.LookupKey(ctx, "test-project", "existing-key")
 	assert.NoError(t, err, "LookupKey failed")
@@ -128,7 +128,7 @@ func TestLookupValueWithFakeGRPCServer(t *testing.T) {
 	valuesClient, err := resourcemanager.NewTagValuesClient(ctx, option.WithGRPCConn(conn))
 	assert.NoError(t, err, "Failed to create TagValuesClient")
 
-	mgr := NewTagsManager(nil, valuesClient)
+	mgr := NewTagsManager(nil, valuesClient, nil)
 
 	value, err := mgr.LookupValue(ctx, "test-project", "existing-key", "existing-value")
 	assert.NoError(t, err, "LookupValue failed")


### PR DESCRIPTION
When managing Google Cloud Redis instances with Config Connector, ensure the resourceID field within the `TagsLocationTagBinding` Kubernetes resource is constructed using the project number in the external reference ID. If the project ID is used instead, Config Connector will attempt to update the immutable `spec.parentRef.external` field with a modified self link containing the project number, leading to reconciliation errors.

Error:
```
apiVersion: tags.cnrm.cloud.google.com/v1alpha1
kind: TagsLocationTagBinding
metadata:
  annotations:
    cnrm.cloud.google.com/management-conflict-prevention-policy: none
    cnrm.cloud.google.com/project-id: PROJECT_ID
    cnrm.cloud.google.com/state-into-spec: absent
  name: tags-location-tag-binding-sample
  namespace: NAMESPACE
  ownerReferences:
  - apiVersion: redis.cnrm.cloud.google.com/v1beta1
    blockOwnerDeletion: true
    controller: true
    kind: RedisInstance
    name: redis-instance-sample
spec:
  location: LOCATION
  parentRef:
    external: //redis.googleapis.com/projects/PROJECT_ID/locations/LOCATION/instances/REDIS_INSTANCE_NAME
  resourceID: tagBindings/%2F%2Fredis.googleapis.com%2Fprojects%2FPROJECT_NUMBER%2Flocations%2FLOCATION%2Finstances%2FREDIS_INSTANCE_NAME/tagValues/TAG_VALUE
  tagValueRef:
    external: tagValues/TAG_VALUE
status:
  conditions:
  - lastTransitionTime: "2024-10-21T13:18:23Z"
    message: 'Update call failed: cannot make changes to immutable field(s): [Field Name: parent, Got: //redis.googleapis.com/projects/PROJECT_ID/locations/LOCATION/instances/REDIS_INSTANCE_NAME, Wanted: //redis.googleapis.com/projects/PROJECT_NUMBER/locations/LOCATION/instances/REDIS_INSTANCE_NAME]; please refer to our troubleshooting doc: https://cloud.google.com/config-connector/docs/troubleshooting'
    reason: UpdateFailed
    status: "False"
    type: Ready
  name: tagBindings/%2F%2Fredis.googleapis.com%2Fprojects%2FPROJECT_NUMBER%2Flocations%2FLOCATION%2Finstances%2FREDIS_INSTANCE_NAME/tagValues/TAG_VALUE
```